### PR TITLE
Implement lightweight backend API and shopping cart functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+backend/data.sqlite3
+backend/__pycache__/
+**/__pycache__/
+*.pyc

--- a/backend/__main__.py
+++ b/backend/__main__.py
@@ -1,0 +1,5 @@
+"""Module entry-point to run the API server with ``python -m backend``."""
+from .server import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,90 @@
+"""Database utilities for the lightweight API backend."""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+DB_PATH = Path(__file__).resolve().parent / "data.sqlite3"
+
+
+def _ensure_db_dir() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def get_connection() -> sqlite3.Connection:
+    """Return a SQLite connection with sensible defaults."""
+    _ensure_db_dir()
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+
+@contextmanager
+def db_cursor() -> Iterator[sqlite3.Cursor]:
+    with get_connection() as conn:
+        cursor = conn.cursor()
+        try:
+            yield cursor
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cursor.close()
+
+
+def init_db() -> None:
+    """Initialise all tables if they do not exist."""
+    schema = """
+    CREATE TABLE IF NOT EXISTS products (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        slug TEXT NOT NULL UNIQUE,
+        description TEXT,
+        price_cents INTEGER NOT NULL,
+        active INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS product_images (
+        id TEXT PRIMARY KEY,
+        product_id TEXT NOT NULL,
+        url TEXT NOT NULL,
+        is_primary INTEGER NOT NULL DEFAULT 0,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY(product_id) REFERENCES products(id) ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS orders (
+        id TEXT PRIMARY KEY,
+        customer_name TEXT NOT NULL,
+        customer_phone TEXT NOT NULL,
+        customer_email TEXT,
+        customer_address TEXT,
+        payment_method TEXT NOT NULL,
+        status TEXT NOT NULL,
+        total_cents INTEGER NOT NULL,
+        notes TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS order_items (
+        id TEXT PRIMARY KEY,
+        order_id TEXT NOT NULL,
+        product_id TEXT NOT NULL,
+        quantity INTEGER NOT NULL,
+        price_cents_at_purchase INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        FOREIGN KEY(order_id) REFERENCES orders(id) ON DELETE CASCADE,
+        FOREIGN KEY(product_id) REFERENCES products(id)
+    );
+    """
+
+    with get_connection() as conn:
+        conn.executescript(schema)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,369 @@
+"""Data access helpers for the lightweight API backend."""
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
+
+from .database import db_cursor, get_connection
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime(ISO_FORMAT)
+
+
+def _bool(value: int | bool) -> bool:
+    return bool(value)
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9-]", "", re.sub(r"\s+", "-", value.lower())).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return slug or uuid4().hex
+
+
+@dataclass
+class ProductImage:
+    id: str
+    product_id: str
+    url: str
+    is_primary: bool
+    sort_order: int
+    created_at: str
+
+
+@dataclass
+class Product:
+    id: str
+    title: str
+    slug: str
+    description: str
+    price_cents: int
+    active: bool
+    created_at: str
+    updated_at: str
+    product_images: List[ProductImage] = field(default_factory=list)
+
+
+@dataclass
+class OrderItem:
+    id: str
+    order_id: str
+    product_id: str
+    quantity: int
+    price_cents_at_purchase: int
+    created_at: str
+    product: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class Order:
+    id: str
+    customer_name: str
+    customer_phone: str
+    customer_email: Optional[str]
+    customer_address: Optional[str]
+    payment_method: str
+    status: str
+    total_cents: int
+    notes: Optional[str]
+    created_at: str
+    updated_at: str
+    order_items: List[OrderItem] = field(default_factory=list)
+
+
+def serialize_product(row: Any) -> Product:
+    return Product(
+        id=row["id"],
+        title=row["title"],
+        slug=row["slug"],
+        description=row["description"] or "",
+        price_cents=int(row["price_cents"]),
+        active=_bool(row["active"]),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def serialize_product_image(row: Any) -> ProductImage:
+    return ProductImage(
+        id=row["id"],
+        product_id=row["product_id"],
+        url=row["url"],
+        is_primary=_bool(row["is_primary"]),
+        sort_order=int(row["sort_order"]),
+        created_at=row["created_at"],
+    )
+
+
+def serialize_order(row: Any) -> Order:
+    return Order(
+        id=row["id"],
+        customer_name=row["customer_name"],
+        customer_phone=row["customer_phone"],
+        customer_email=row["customer_email"],
+        customer_address=row["customer_address"],
+        payment_method=row["payment_method"],
+        status=row["status"],
+        total_cents=int(row["total_cents"]),
+        notes=row["notes"],
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def serialize_order_item(row: Any) -> OrderItem:
+    return OrderItem(
+        id=row["id"],
+        order_id=row["order_id"],
+        product_id=row["product_id"],
+        quantity=int(row["quantity"]),
+        price_cents_at_purchase=int(row["price_cents_at_purchase"]),
+        created_at=row["created_at"],
+    )
+
+
+def list_products(search: Optional[str] = None) -> List[Dict[str, Any]]:
+    sql = "SELECT * FROM products"
+    params: List[Any] = []
+    if search:
+        sql += " WHERE lower(title) LIKE ? OR lower(description) LIKE ?"
+        like_value = f"%{search.lower()}%"
+        params.extend([like_value, like_value])
+    sql += " ORDER BY datetime(created_at) DESC"
+
+    with get_connection() as conn:
+        rows = conn.execute(sql, params).fetchall()
+
+    products: List[Dict[str, Any]] = []
+    for row in rows:
+        product = serialize_product(row)
+        product.product_images = list_product_images(product.id)
+        products.append(asdict(product))
+    return products
+
+
+def list_product_images(product_id: str) -> List[ProductImage]:
+    with get_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT * FROM product_images
+            WHERE product_id = ?
+            ORDER BY is_primary DESC, sort_order ASC, datetime(created_at) ASC
+            """,
+            (product_id,),
+        ).fetchall()
+    return [serialize_product_image(row) for row in rows]
+
+
+def get_product_by_slug(slug: str) -> Optional[Dict[str, Any]]:
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM products WHERE slug = ?", (slug,)).fetchone()
+    if not row:
+        return None
+    product = serialize_product(row)
+    product.product_images = list_product_images(product.id)
+    return asdict(product)
+
+
+def create_product(payload: Dict[str, Any]) -> Dict[str, Any]:
+    title = (payload.get("title") or "").strip()
+    if not title:
+        raise ValueError("Title is required.")
+
+    slug = (payload.get("slug") or _slugify(title)).strip()
+    description = (payload.get("description") or "").strip()
+    price_cents = int(payload.get("price_cents") or 0)
+    if price_cents <= 0:
+        raise ValueError("price_cents must be greater than 0.")
+    active = bool(payload.get("active", True))
+
+    now = _utc_now()
+    product_id = payload.get("id") or str(uuid4())
+
+    with db_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO products (id, title, slug, description, price_cents, active, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (product_id, title, slug, description, price_cents, int(active), now, now),
+        )
+
+    images_payload = payload.get("product_images") or []
+    for index, image_payload in enumerate(images_payload):
+        create_product_image(product_id, image_payload, index)
+
+    return get_product_by_slug(slug)  # type: ignore[return-value]
+
+
+def create_product_image(product_id: str, payload: Dict[str, Any], fallback_order: int) -> ProductImage:
+    image_id = payload.get("id") or str(uuid4())
+    url = (payload.get("url") or "").strip()
+    if not url:
+        raise ValueError("Image url is required.")
+    is_primary = bool(payload.get("is_primary", False))
+    sort_order = int(payload.get("sort_order") or fallback_order)
+    created_at = payload.get("created_at") or _utc_now()
+
+    with db_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO product_images (id, product_id, url, is_primary, sort_order, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (image_id, product_id, url, int(is_primary), sort_order, created_at),
+        )
+    return ProductImage(
+        id=image_id,
+        product_id=product_id,
+        url=url,
+        is_primary=is_primary,
+        sort_order=sort_order,
+        created_at=created_at,
+    )
+
+
+def _fetch_product_price(product_id: str) -> int:
+    with get_connection() as conn:
+        row = conn.execute("SELECT price_cents FROM products WHERE id = ? AND active = 1", (product_id,)).fetchone()
+    if not row:
+        raise ValueError("Product not found or inactive.")
+    return int(row["price_cents"])
+
+
+def create_order(payload: Dict[str, Any]) -> Dict[str, Any]:
+    customer_name = (payload.get("customer_name") or "").strip()
+    customer_phone = (payload.get("customer_phone") or "").strip()
+    customer_email = (payload.get("customer_email") or None) or None
+    customer_address = (payload.get("customer_address") or None) or None
+    notes = (payload.get("notes") or None) or None
+    payment_method = (payload.get("payment_method") or "cash_on_delivery").strip() or "cash_on_delivery"
+    status = "new"
+
+    if not customer_name:
+        raise ValueError("customer_name is required.")
+    if not customer_phone:
+        raise ValueError("customer_phone is required.")
+
+    items_payload = payload.get("items")
+    if not isinstance(items_payload, list) or not items_payload:
+        raise ValueError("At least one item is required.")
+
+    now = _utc_now()
+    order_id = payload.get("id") or str(uuid4())
+
+    order_items: List[Dict[str, Any]] = []
+    total_cents = 0
+
+    for raw_item in items_payload:
+        product_id = (raw_item.get("product_id") or raw_item.get("productId") or "").strip()
+        quantity = int(raw_item.get("quantity") or 0)
+        if not product_id:
+            raise ValueError("Each item requires a product_id.")
+        if quantity <= 0:
+            raise ValueError("quantity must be greater than 0.")
+
+        price_cents = _fetch_product_price(product_id)
+        total_cents += price_cents * quantity
+        order_items.append(
+            {
+                "id": str(uuid4()),
+                "order_id": order_id,
+                "product_id": product_id,
+                "quantity": quantity,
+                "price_cents_at_purchase": price_cents,
+                "created_at": now,
+            }
+        )
+
+    if total_cents <= 0:
+        raise ValueError("total_cents must be greater than 0.")
+
+    with db_cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO orders (
+                id, customer_name, customer_phone, customer_email, customer_address,
+                payment_method, status, total_cents, notes, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                order_id,
+                customer_name,
+                customer_phone,
+                customer_email,
+                customer_address,
+                payment_method,
+                status,
+                total_cents,
+                notes,
+                now,
+                now,
+            ),
+        )
+
+    for item in order_items:
+        with db_cursor() as cursor:
+            cursor.execute(
+                """
+                INSERT INTO order_items (id, order_id, product_id, quantity, price_cents_at_purchase, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    item["id"],
+                    item["order_id"],
+                    item["product_id"],
+                    item["quantity"],
+                    item["price_cents_at_purchase"],
+                    item["created_at"],
+                ),
+            )
+
+    return get_order(order_id)
+
+
+def list_orders() -> List[Dict[str, Any]]:
+    with get_connection() as conn:
+        rows = conn.execute("SELECT * FROM orders ORDER BY datetime(created_at) DESC").fetchall()
+    orders = []
+    for row in rows:
+        orders.append(get_order(row["id"]))
+    return orders
+
+
+def get_order(order_id: str) -> Dict[str, Any]:
+    with get_connection() as conn:
+        order_row = conn.execute("SELECT * FROM orders WHERE id = ?", (order_id,)).fetchone()
+        if not order_row:
+            raise ValueError("Order not found.")
+        item_rows = conn.execute("SELECT * FROM order_items WHERE order_id = ?", (order_id,)).fetchall()
+
+    order = serialize_order(order_row)
+    items: List[OrderItem] = []
+    for item_row in item_rows:
+        item = serialize_order_item(item_row)
+        product = get_product_with_id(item.product_id)
+        if product:
+            item.product = product
+        items.append(item)
+    order.order_items = items
+    result = asdict(order)
+    # convert nested dataclasses to dicts
+    result["order_items"] = [asdict(item) for item in items]
+    return result
+
+
+def get_product_with_id(product_id: str) -> Optional[Dict[str, Any]]:
+    with get_connection() as conn:
+        row = conn.execute("SELECT * FROM products WHERE id = ?", (product_id,)).fetchone()
+    if not row:
+        return None
+    product = serialize_product(row)
+    product.product_images = list_product_images(product.id)
+    return asdict(product)

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,170 @@
+"""Minimal HTTP API server providing product and order endpoints."""
+from __future__ import annotations
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Dict, Optional
+from urllib.parse import parse_qs, urlparse
+
+from .database import init_db
+from . import models
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8000
+
+
+def _json_bytes(data: Any) -> bytes:
+    return json.dumps(data, ensure_ascii=False).encode("utf-8")
+
+
+class ApiRequestHandler(BaseHTTPRequestHandler):
+    server_version = "CharmCatalogAPI/1.0"
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A003 - keeping BaseHTTPRequestHandler signature
+        # Print concise access logs to stdout
+        message = "%s - - [%s] %s" % (self.address_string(), self.log_date_time_string(), format % args)
+        print(message)
+
+    def _set_common_headers(self, status: HTTPStatus, content_length: int) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(content_length))
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Connection", "close")
+
+    def _write_json(self, status: HTTPStatus, payload: Any) -> None:
+        body = _json_bytes(payload)
+        self._set_common_headers(status, len(body))
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+        self.wfile.flush()
+        self.close_connection = True
+
+    def _parse_json_body(self) -> Dict[str, Any]:
+        length = int(self.headers.get("Content-Length", 0))
+        if length <= 0:
+            return {}
+        data = self.rfile.read(length)
+        if not data:
+            return {}
+        try:
+            return json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid JSON payload.") from exc
+
+    def do_OPTIONS(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        self.send_response(HTTPStatus.NO_CONTENT)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET,POST,OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.send_header("Content-Length", "0")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        self.close_connection = True
+
+    def do_GET(self) -> None:  # noqa: N802 - required naming
+        parsed = urlparse(self.path)
+        segments = [segment for segment in parsed.path.split("/") if segment]
+
+        try:
+            if len(segments) >= 2 and segments[0] == "api" and segments[1] == "products":
+                self._handle_products_get(segments, parse_qs(parsed.query))
+            elif len(segments) >= 2 and segments[0] == "api" and segments[1] == "orders":
+                self._handle_orders_get(segments)
+            else:
+                self._write_json(HTTPStatus.NOT_FOUND, {"detail": "Endpoint not found."})
+        except ValueError as exc:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"detail": str(exc)})
+        except Exception as exc:  # pragma: no cover - defensive
+            self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"detail": str(exc)})
+
+    def do_POST(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+        segments = [segment for segment in parsed.path.split("/") if segment]
+
+        try:
+            if len(segments) >= 2 and segments[0] == "api" and segments[1] == "products":
+                payload = self._parse_json_body()
+                product = models.create_product(payload)
+                self._write_json(HTTPStatus.CREATED, product)
+            elif len(segments) >= 2 and segments[0] == "api" and segments[1] == "orders":
+                payload = self._parse_json_body()
+                order = models.create_order(payload)
+                self._write_json(HTTPStatus.CREATED, order)
+            else:
+                self._write_json(HTTPStatus.NOT_FOUND, {"detail": "Endpoint not found."})
+        except ValueError as exc:
+            self._write_json(HTTPStatus.BAD_REQUEST, {"detail": str(exc)})
+        except Exception as exc:  # pragma: no cover - defensive
+            self._write_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"detail": str(exc)})
+
+    # Endpoint helpers -----------------------------------------------------
+
+    def _handle_products_get(self, segments: list[str], query: Dict[str, list[str]]) -> None:
+        if len(segments) == 2:
+            search = query.get("search", [None])[0] if query else None
+            products = models.list_products(search)
+            self._write_json(HTTPStatus.OK, products)
+            return
+
+        if len(segments) == 3:
+            slug = segments[2]
+            product = models.get_product_by_slug(slug)
+            if not product:
+                self._write_json(HTTPStatus.NOT_FOUND, {"detail": "Product not found."})
+                return
+            self._write_json(HTTPStatus.OK, product)
+            return
+
+        self._write_json(HTTPStatus.NOT_FOUND, {"detail": "Endpoint not found."})
+
+    def _handle_orders_get(self, segments: list[str]) -> None:
+        if len(segments) == 2:
+            orders = models.list_orders()
+            self._write_json(HTTPStatus.OK, orders)
+            return
+
+        if len(segments) == 3:
+            order_id = segments[2]
+            try:
+                order = models.get_order(order_id)
+            except ValueError as exc:
+                self._write_json(HTTPStatus.NOT_FOUND, {"detail": str(exc)})
+                return
+            self._write_json(HTTPStatus.OK, order)
+            return
+
+        self._write_json(HTTPStatus.NOT_FOUND, {"detail": "Endpoint not found."})
+
+
+def run_server(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> None:
+    init_db()
+    with ThreadingHTTPServer((host, port), ApiRequestHandler) as httpd:
+        print(f"🚀 Charm Catalog API running on http://{host}:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping server...")
+        finally:
+            httpd.server_close()
+
+
+def parse_args(args: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Charm Catalog API server")
+    parser.add_argument("--host", default=DEFAULT_HOST, help="Host interface to bind")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Port to listen on")
+    return parser.parse_args(args=args)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    options = parse_args(argv)
+    run_server(options.host, options.port)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/frontend/src/components/site/CartSheet.tsx
+++ b/frontend/src/components/site/CartSheet.tsx
@@ -1,0 +1,255 @@
+import { useState } from "react";
+import { Minus, Plus, ShoppingCart, Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { Textarea } from "@/components/ui/textarea";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { useCart } from "@/contexts/CartContext";
+import { useToast } from "@/hooks/use-toast";
+import { submitOrderRequest } from "@/lib/api";
+import { formatEUR } from "@/lib/utils";
+
+const initialFormState = {
+  customerName: "",
+  customerPhone: "",
+  customerEmail: "",
+  customerAddress: "",
+  notes: "",
+};
+
+export function CartSheet() {
+  const { items, itemCount, totalCents, removeItem, updateQuantity, clearCart, isOpen, setOpen } = useCart();
+  const { toast } = useToast();
+  const [formData, setFormData] = useState(initialFormState);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleQuantityChange = (productId: string, delta: number) => {
+    const current = items.find((item) => item.product.id === productId);
+    if (!current) return;
+    const nextQuantity = current.quantity + delta;
+    if (nextQuantity <= 0) {
+      removeItem(productId);
+      return;
+    }
+    updateQuantity(productId, nextQuantity);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!items.length) return;
+
+    if (!formData.customerName || !formData.customerPhone) {
+      toast({
+        title: "Недостасуваат податоци",
+        description: "Внесете ги вашето име и телефон за да ја потврдите нарачката.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const order = await submitOrderRequest({
+        customerName: formData.customerName,
+        customerPhone: formData.customerPhone,
+        customerEmail: formData.customerEmail || undefined,
+        customerAddress: formData.customerAddress || undefined,
+        notes: formData.notes || undefined,
+        items: items.map((item) => ({ productId: item.product.id, quantity: item.quantity })),
+      });
+
+      toast({
+        title: "Нарачката е испратена",
+        description: `Број на барање: ${order.id}. Ќе ве контактираме за потврда.`,
+      });
+
+      clearCart();
+      setFormData(initialFormState);
+      setOpen(false);
+    } catch (error: any) {
+      toast({
+        title: "Грешка",
+        description: error?.message || "Не успеавме да ја испратиме вашата нарачка. Обидете се повторно.",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Sheet open={isOpen} onOpenChange={setOpen}>
+      <SheetTrigger asChild>
+        <Button variant="outline" size="sm" className="relative">
+          <ShoppingCart className="h-4 w-4" />
+          {itemCount > 0 && (
+            <span className="absolute -top-2 -right-2 inline-flex h-5 min-w-[20px] items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground px-1">
+              {itemCount}
+            </span>
+          )}
+        </Button>
+      </SheetTrigger>
+      <SheetContent side="right" className="sm:max-w-lg flex flex-col">
+        <SheetHeader>
+          <SheetTitle>Ваша кошничка</SheetTitle>
+          <SheetDescription>
+            Плаќањето е при достава. Проверете ги артиклите и потврдете ја нарачката.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex-1 overflow-hidden py-4">
+          {items.length === 0 ? (
+            <div className="h-full flex flex-col items-center justify-center text-center text-muted-foreground gap-2">
+              <ShoppingCart className="h-10 w-10" />
+              <p>Вашата кошничка е празна. Додајте производи за да продолжите.</p>
+            </div>
+          ) : (
+            <ScrollArea className="h-full pr-4">
+              <div className="space-y-4">
+                {items.map((item) => {
+                  const primaryImage = item.product.product_images?.[0]?.url;
+                  return (
+                    <div key={item.product.id} className="flex gap-4 rounded-lg border border-border/50 p-4">
+                      <div className="h-20 w-20 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                        {primaryImage ? (
+                          <img src={primaryImage} alt={item.product.title} className="h-full w-full object-cover" />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center text-2xl">🌿</div>
+                        )}
+                      </div>
+
+                      <div className="flex flex-1 flex-col gap-2">
+                        <div className="flex items-start justify-between gap-2">
+                          <div>
+                            <p className="font-medium leading-tight text-foreground">{item.product.title}</p>
+                            <p className="text-sm text-muted-foreground">{formatEUR(item.product.price_cents)}</p>
+                          </div>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                            onClick={() => removeItem(item.product.id)}
+                            aria-label="Отстрани"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => handleQuantityChange(item.product.id, -1)}
+                              aria-label="Намали количина"
+                            >
+                              <Minus className="h-3 w-3" />
+                            </Button>
+                            <span className="w-8 text-center text-sm font-medium">{item.quantity}</span>
+                            <Button
+                              variant="outline"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={() => handleQuantityChange(item.product.id, 1)}
+                              aria-label="Зголеми количина"
+                            >
+                              <Plus className="h-3 w-3" />
+                            </Button>
+                          </div>
+                          <span className="text-sm font-semibold text-foreground">
+                            {formatEUR(item.product.price_cents * item.quantity)}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </ScrollArea>
+          )}
+        </div>
+
+        {items.length > 0 && (
+          <div className="border-t border-border/50 pt-4 space-y-4">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>Вкупно ({itemCount} артикли)</span>
+              <span className="text-lg font-semibold text-primary">{formatEUR(totalCents)}</span>
+            </div>
+
+            <Badge variant="outline" className="w-full justify-center border-primary text-primary bg-primary/5">
+              Плати при достава
+            </Badge>
+
+            <Separator />
+
+            <form onSubmit={handleSubmit} className="space-y-3">
+              <div className="grid gap-2">
+                <Label htmlFor="cart-name">Име и презиме *</Label>
+                <Input
+                  id="cart-name"
+                  placeholder="Пример: Ана Анастасова"
+                  value={formData.customerName}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, customerName: event.target.value }))}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cart-phone">Телефон *</Label>
+                <Input
+                  id="cart-phone"
+                  placeholder="07X XXX XXX"
+                  value={formData.customerPhone}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, customerPhone: event.target.value }))}
+                  required
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cart-email">Е-пошта</Label>
+                <Input
+                  id="cart-email"
+                  type="email"
+                  placeholder="optional@example.com"
+                  value={formData.customerEmail}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, customerEmail: event.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cart-address">Адреса за достава</Label>
+                <Input
+                  id="cart-address"
+                  placeholder="Ул. Пример бр. 1, Скопје"
+                  value={formData.customerAddress}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, customerAddress: event.target.value }))}
+                />
+              </div>
+
+              <div className="grid gap-2">
+                <Label htmlFor="cart-notes">Забелешка</Label>
+                <Textarea
+                  id="cart-notes"
+                  placeholder="Дополнителни информации за доставата"
+                  value={formData.notes}
+                  onChange={(event) => setFormData((prev) => ({ ...prev, notes: event.target.value }))}
+                  rows={3}
+                />
+              </div>
+
+              <Button type="submit" className="w-full" disabled={submitting}>
+                {submitting ? "Испраќање..." : "Потврди нарачка"}
+              </Button>
+            </form>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/frontend/src/components/site/FeaturedGrid.tsx
+++ b/frontend/src/components/site/FeaturedGrid.tsx
@@ -1,62 +1,74 @@
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { fetchProducts, type Product, type ProductImage } from "@/lib/api";
 import { formatEUR } from "@/lib/utils";
 
-// Placeholder data - this will be replaced with real data from the database
-const featuredProducts = [
+const placeholderProducts = [
   {
-    id: "1",
+    id: "placeholder-1",
     title: "Билна мешавина за имунитет",
-    image: null,
-    oldPrice: 2500,
-    currentPrice: 1990,
+    oldPrice: 250000,
+    currentPrice: 199000,
     slug: "bilna-mesavina-imunitet"
   },
   {
-    id: "2", 
+    id: "placeholder-2",
     title: "Природен крем за лице",
-    image: null,
-    oldPrice: 1800,
-    currentPrice: 1490,
+    oldPrice: 180000,
+    currentPrice: 149000,
     slug: "priroden-krem-lice"
   },
   {
-    id: "3",
+    id: "placeholder-3",
     title: "Серум за коса",
-    image: null,
-    oldPrice: 2200,
-    currentPrice: 1790,
+    oldPrice: 220000,
+    currentPrice: 179000,
     slug: "serum-kosa"
   },
   {
-    id: "4",
+    id: "placeholder-4",
     title: "Детокс чај",
-    image: null,
-    oldPrice: 1500,
-    currentPrice: 1190,
+    oldPrice: 150000,
+    currentPrice: 119000,
     slug: "detoks-caj"
   },
   {
-    id: "5",
+    id: "placeholder-5",
     title: "Антиоксидантен комплекс",
-    image: null,
-    oldPrice: 2800,
-    currentPrice: 2390,
+    oldPrice: 280000,
+    currentPrice: 239000,
     slug: "antioksidanten-kompleks"
   },
   {
-    id: "6",
+    id: "placeholder-6",
     title: "Природно масло за тело",
-    image: null,
-    oldPrice: 1900,
-    currentPrice: 1590,
+    oldPrice: 190000,
+    currentPrice: 159000,
     slug: "prirodno-maslo-telo"
   }
 ];
 
 export function FeaturedGrid() {
+  const [products, setProducts] = useState<(Product & { product_images?: ProductImage[] })[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const catalog = await fetchProducts();
+        setProducts(catalog.slice(0, 6));
+      } catch (error) {
+        console.error("Error loading featured products:", error);
+      }
+    };
+
+    load();
+  }, []);
+
+  const displayProducts = products.length ? products : placeholderProducts;
+
   return (
     <section className="py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -70,52 +82,67 @@ export function FeaturedGrid() {
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-          {featuredProducts.map((product) => (
-            <Card key={product.id} className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20">
-              <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
-                {/* Placeholder for product image */}
-                <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
-                  <div className="text-center">
-                    <div className="text-4xl mb-2">🌿</div>
-                    <p className="text-xs text-muted-foreground">Слика на производ</p>
+          {displayProducts.map((product) => {
+            const isPlaceholder = "currentPrice" in product;
+            const currentPrice = isPlaceholder
+              ? (product as typeof placeholderProducts[number]).currentPrice
+              : (product as Product).price_cents;
+            const oldPrice = isPlaceholder
+              ? (product as typeof placeholderProducts[number]).oldPrice
+              : Math.round((product as Product).price_cents * 1.15);
+            const slug = (product as any).slug;
+            const images = !isPlaceholder ? (product as Product & { product_images?: ProductImage[] }).product_images : undefined;
+            const primaryImage = images && images.length ? images[0]?.url : null;
+
+            return (
+              <Card key={product.id} className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20">
+                <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
+                  <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
+                    {primaryImage ? (
+                      <img src={primaryImage} alt={product.title} className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300" />
+                    ) : (
+                      <div className="text-center">
+                        <div className="text-4xl mb-2">🌿</div>
+                        <p className="text-xs text-muted-foreground">Слика на производ</p>
+                      </div>
+                    )}
                   </div>
+
+                  <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
+                    -{Math.round(((oldPrice - currentPrice) / oldPrice) * 100)}%
+                  </Badge>
                 </div>
-                
-                {/* Discount badge */}
-                <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
-                  -{Math.round(((product.oldPrice - product.currentPrice) / product.oldPrice) * 100)}%
-                </Badge>
-              </div>
-              
-              <CardContent className="p-4">
-                <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors">
-                  {product.title}
-                </h3>
-                
-                <p className="text-sm text-muted-foreground mb-3">
-                  Природен производ со сертифицирани состојки за максимална ефикасност.
-                </p>
-                
-                <div className="flex items-center space-x-2">
-                  <span className="text-lg font-bold text-primary">
-                    {formatEUR(product.currentPrice)}
-                  </span>
-                  <span className="text-sm text-muted-foreground line-through">
-                    {formatEUR(product.oldPrice)}
-                  </span>
-                </div>
-              </CardContent>
-              
-              <CardFooter className="p-4 pt-0 flex gap-2">
-                <Button asChild className="flex-1 bg-primary hover:bg-primary-light">
-                  <Link to={`/products/${product.slug}`}>Нарачај</Link>
-                </Button>
-                <Button asChild variant="outline" className="border-primary text-primary hover:bg-primary hover:text-primary-foreground">
-                  <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
-                </Button>
-              </CardFooter>
-            </Card>
-          ))}
+
+                <CardContent className="p-4">
+                  <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                    {product.title}
+                  </h3>
+
+                  <p className="text-sm text-muted-foreground mb-3">
+                    Природен производ со сертифицирани состојки за максимална ефикасност.
+                  </p>
+
+                  <div className="flex items-center space-x-2">
+                    <span className="text-lg font-bold text-primary">
+                      {formatEUR(currentPrice)}
+                    </span>
+                    <span className="text-sm text-muted-foreground line-through">
+                      {formatEUR(oldPrice)}
+                    </span>
+                  </div>
+                </CardContent>
+
+                <CardFooter className="p-4 pt-0 flex gap-2">
+                  <Button asChild className="flex-1 bg-primary hover:bg-primary-light">
+                    <Link to={`/products/${slug}`}>Нарачај</Link>
+                  </Button>
+                  <Button asChild variant="outline" className="border-primary text-primary hover:bg-primary hover:text-primary-foreground">
+                    <Link to={`/products/${slug}`}>Повеќе инфо</Link>
+                  </Button>
+                </CardFooter>
+              </Card>
+            );
+          })}
         </div>
 
         <div className="text-center">

--- a/frontend/src/components/site/Navbar.tsx
+++ b/frontend/src/components/site/Navbar.tsx
@@ -4,6 +4,7 @@ import { Menu, X, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
+import { CartSheet } from "./CartSheet";
 
 const navigation = [
   { name: "ПОЧЕТНА", href: "/" },
@@ -50,6 +51,8 @@ export function Navbar() {
             <Button variant="ghost" size="sm" className="hidden sm:flex">
               <Search className="h-4 w-4" />
             </Button>
+
+            <CartSheet />
 
             {/* Mobile menu */}
             <Sheet open={isOpen} onOpenChange={setIsOpen}>

--- a/frontend/src/contexts/CartContext.tsx
+++ b/frontend/src/contexts/CartContext.tsx
@@ -1,0 +1,126 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+import type { Product } from "@/lib/types";
+
+export interface CartItem {
+  product: Product;
+  quantity: number;
+}
+
+interface CartContextValue {
+  items: CartItem[];
+  itemCount: number;
+  totalCents: number;
+  addItem: (product: Product, quantity?: number) => void;
+  removeItem: (productId: string) => void;
+  updateQuantity: (productId: string, quantity: number) => void;
+  clearCart: () => void;
+  isOpen: boolean;
+  setOpen: (open: boolean) => void;
+  openCart: () => void;
+}
+
+const STORAGE_KEY = "charm_catalog_cart";
+
+const CartContext = createContext<CartContextValue | undefined>(undefined);
+
+function readStoredCart(): CartItem[] {
+  if (typeof window === "undefined") {
+    return [];
+  }
+
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+
+    const parsed = JSON.parse(stored) as CartItem[];
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return parsed.filter((item) => item?.product?.id && item.quantity > 0);
+  } catch (error) {
+    console.warn("Failed to read cart from storage", error);
+    return [];
+  }
+}
+
+export function CartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<CartItem[]>(() => readStoredCart());
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+    } catch (error) {
+      console.warn("Failed to persist cart", error);
+    }
+  }, [items]);
+
+  const addItem = useCallback((product: Product, quantity = 1) => {
+    setItems((current) => {
+      const existing = current.find((item) => item.product.id === product.id);
+      if (existing) {
+        return current.map((item) =>
+          item.product.id === product.id
+            ? { ...item, quantity: Math.max(1, item.quantity + quantity) }
+            : item
+        );
+      }
+
+      return [...current, { product, quantity: Math.max(1, quantity) }];
+    });
+  }, []);
+
+  const removeItem = useCallback((productId: string) => {
+    setItems((current) => current.filter((item) => item.product.id !== productId));
+  }, []);
+
+  const updateQuantity = useCallback((productId: string, quantity: number) => {
+    setItems((current) =>
+      current
+        .map((item) =>
+          item.product.id === productId
+            ? { ...item, quantity: quantity < 1 ? 1 : quantity }
+            : item
+        )
+        .filter((item) => item.quantity > 0)
+    );
+  }, []);
+
+  const clearCart = useCallback(() => setItems([]), []);
+
+  const openCart = useCallback(() => setIsOpen(true), []);
+
+  const totals = useMemo(() => {
+    const totalCents = items.reduce((sum, item) => sum + item.product.price_cents * item.quantity, 0);
+    const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
+    return { totalCents, itemCount };
+  }, [items]);
+
+  const value = useMemo<CartContextValue>(() => ({
+    items,
+    itemCount: totals.itemCount,
+    totalCents: totals.totalCents,
+    addItem,
+    removeItem,
+    updateQuantity,
+    clearCart,
+    isOpen,
+    setOpen: setIsOpen,
+    openCart,
+  }), [items, totals.itemCount, totals.totalCents, addItem, removeItem, updateQuantity, clearCart, isOpen, openCart]);
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+}
+
+export function useCart(): CartContextValue {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error("useCart must be used within a CartProvider");
+  }
+  return context;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,63 +1,81 @@
-import { products as staticProducts } from "@/data/products";
-import type { Product, ProductImage } from "@/lib/types";
+import type { Order, Product, ProductImage } from "@/lib/types";
 
-const NETWORK_DELAY = 300;
+const DEFAULT_API_BASE_URL = "http://localhost:8000";
+const API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || DEFAULT_API_BASE_URL).replace(/\/$/, "");
 
-const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(options.headers || {}),
+    },
+    ...options,
+  });
 
-// Simulate fetching products from an API. Replace with real fetch calls later.
-export async function fetchProducts(): Promise<(Product & { product_images?: ProductImage[] })[]> {
-  await delay(NETWORK_DELAY);
+  const text = await response.text();
+  const data = text ? (JSON.parse(text) as T & { detail?: string }) : null;
 
-  return staticProducts
-    .filter((product) => product.active)
-    .map((product) => ({
-      ...product,
-      product_images: product.product_images
-        ? [...product.product_images].sort((a, b) => {
-            if (a.is_primary && !b.is_primary) return -1;
-            if (!a.is_primary && b.is_primary) return 1;
-            return a.sort_order - b.sort_order;
-          })
-        : []
-    }))
-    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+  if (!response.ok) {
+    const detail = (data && typeof data === "object" && "detail" in data && data.detail) || response.statusText;
+    throw new Error(detail || "Request failed");
+  }
+
+  return data as T;
+}
+
+export async function fetchProducts(search?: string): Promise<(Product & { product_images?: ProductImage[] })[]> {
+  const query = search ? `?search=${encodeURIComponent(search)}` : "";
+  return request<(Product & { product_images?: ProductImage[] })[]>(`/api/products${query}`);
 }
 
 export async function fetchProductBySlug(slug: string): Promise<(Product & { product_images?: ProductImage[] }) | null> {
-  await delay(NETWORK_DELAY);
+  const response = await fetch(`${API_BASE_URL}/api/products/${slug}`);
 
-  const product = staticProducts.find((item) => item.slug === slug && item.active);
-  if (!product) {
+  if (response.status === 404) {
     return null;
   }
 
-  return {
-    ...product,
-    product_images: product.product_images
-      ? [...product.product_images].sort((a, b) => {
-          if (a.is_primary && !b.is_primary) return -1;
-          if (!a.is_primary && b.is_primary) return 1;
-          return a.sort_order - b.sort_order;
-        })
-      : []
-  };
+  if (!response.ok) {
+    const text = await response.text();
+    const detail = text ? (JSON.parse(text) as { detail?: string }).detail : null;
+    throw new Error(detail || response.statusText);
+  }
+
+  const data = (await response.json()) as Product & { product_images?: ProductImage[] };
+  return data;
 }
 
-interface OrderRequestPayload {
-  productId: string;
-  quantity: number;
+export interface OrderRequestPayload {
   customerName: string;
   customerPhone: string;
   customerEmail?: string;
   customerAddress?: string;
   notes?: string;
+  paymentMethod?: string;
+  items: Array<{
+    productId: string;
+    quantity: number;
+  }>;
 }
 
-// Placeholder order submission that mimics a network request and logs the payload.
-export async function submitOrderRequest(payload: OrderRequestPayload): Promise<void> {
-  await delay(NETWORK_DELAY);
-  console.info("Order request queued for backend integration", payload);
+export async function submitOrderRequest(payload: OrderRequestPayload): Promise<Order> {
+  const body = {
+    customer_name: payload.customerName,
+    customer_phone: payload.customerPhone,
+    customer_email: payload.customerEmail,
+    customer_address: payload.customerAddress,
+    notes: payload.notes,
+    payment_method: payload.paymentMethod || "cash_on_delivery",
+    items: payload.items.map((item) => ({
+      product_id: item.productId,
+      quantity: item.quantity,
+    })),
+  };
+
+  return request<Order>("/api/orders", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }
 
 export type { Product, ProductImage };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -20,15 +20,6 @@ export interface Product {
   product_images?: ProductImage[];
 }
 
-export interface Customer {
-  id: string;
-  name: string;
-  phone: string;
-  email?: string;
-  address?: string;
-  created_at: string;
-}
-
 export interface OrderItem {
   id: string;
   order_id: string;
@@ -41,14 +32,16 @@ export interface OrderItem {
 
 export interface Order {
   id: string;
-  customer_id: string;
+  customer_name: string;
+  customer_phone: string;
+  customer_email?: string;
+  customer_address?: string;
   status: "new" | "contacted" | "scheduled" | "fulfilled" | "canceled";
   payment_method: string;
   total_cents: number;
   notes?: string;
   created_at: string;
   updated_at: string;
-  customer?: Customer;
   order_items?: OrderItem[];
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import { CartProvider } from "./contexts/CartContext";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <CartProvider>
+    <App />
+  </CartProvider>
+);


### PR DESCRIPTION
## Summary
- add a lightweight Python HTTP API with SQLite persistence for products, images, and cash-on-delivery orders
- update the React app to fetch catalog data from the backend and align shared types
- add a reusable cart context and slide-over basket UI with checkout that submits multi-item orders

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68deaf14f5148330b4dc3a76e128f5b7