### PR TITLE
Normalize product search queries in frontend

### DIFF
--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -21,6 +21,7 @@ export default function ProductsPage() {
   const [searchParams] = useSearchParams();
 
   const searchQuery = useMemo(() => (searchParams.get("search") || "").trim(), [searchParams]);
+  const normalizedSearchQuery = useMemo(() => searchQuery.toLocaleLowerCase(), [searchQuery]);
 
   const {
     data: products = [],
@@ -28,8 +29,8 @@ export default function ProductsPage() {
     isFetching,
     error,
   } = useQuery<Product[], Error>({
-    queryKey: ["products", searchQuery],
-    queryFn: ({ signal }) => fetchProducts(searchQuery || undefined, signal),
+    queryKey: ["products", normalizedSearchQuery],
+    queryFn: ({ signal }) => fetchProducts(normalizedSearchQuery || undefined, signal),
     keepPreviousData: true,
     staleTime: 1000 * 30,
   });


### PR DESCRIPTION
## Summary
- normalize product search queries before requesting products so the backend receives a consistent lowercase value

## Testing
- npm run lint *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68dedbf59aac8330a0e063e3abb50604