### PR TITLE
Use static product data throughout storefront

### DIFF
--- a/frontend/src/components/site/FeaturedGrid.tsx
+++ b/frontend/src/components/site/FeaturedGrid.tsx
@@ -1,31 +1,13 @@
 import { Link } from "react-router-dom";
-import { useQuery } from "@tanstack/react-query";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { fetchProducts, type Product } from "@/lib/api";
 import { formatEUR } from "@/lib/utils";
-
-import { mockProducts } from "@/assets/products/mockProducts";
+import { staticProducts } from "@/data/staticProducts";
 
 export function FeaturedGrid() {
-  const {
-    data: products = [],
-    isLoading,
-    error,
-  } = useQuery<Product[], Error>({
-    queryKey: ["featured-products"],
-    queryFn: ({ signal }) => fetchProducts(undefined, signal),
-    staleTime: 1000 * 60,
-  });
-
-  // ✅ Use mock products if API fails or is empty
-  const featuredProducts =
-    !isLoading && products.length > 0 ? products.slice(0, 6) : mockProducts;
-
-  const errorMessage =
-    error?.message ||
-    (error ? "Не можеме да ги вчитаме препорачаните производи." : null);
+  const featuredProducts = staticProducts.slice(0, 5);
 
   return (
     <section className="py-16">
@@ -39,126 +21,78 @@ export function FeaturedGrid() {
           </p>
         </div>
 
-        {isLoading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-            {[...Array(6)].map((_, index) => (
-              <Card key={index} className="animate-pulse">
-                <div className="aspect-[4/3] bg-muted" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+          {featuredProducts.map((product) => {
+            const currentPrice = Number(product.price) || 0;
+            const oldPrice = Math.round(currentPrice * 1.15 * 100) / 100;
+            const discount =
+              oldPrice > 0 ? Math.round(((oldPrice - currentPrice) / oldPrice) * 100) : 0;
+            const primaryImage =
+              product.primary_image_url || product.image || product.image_url || null;
+
+            return (
+              <Card
+                key={product.id}
+                className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
+              >
+                <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
+                  <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
+                    {primaryImage ? (
+                      <img
+                        src={primaryImage}
+                        alt={product.title}
+                        className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="text-center">
+                        <div className="text-4xl mb-2">🌿</div>
+                        <p className="text-xs text-muted-foreground">Слика на производ</p>
+                      </div>
+                    )}
+                  </div>
+                  {discount > 0 && (
+                    <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
+                      -{discount}%
+                    </Badge>
+                  )}
+                </div>
+
                 <CardContent className="p-4">
-                  <div className="h-4 bg-muted rounded mb-2" />
-                  <div className="h-3 bg-muted rounded mb-3 w-3/4" />
-                  <div className="h-4 bg-muted rounded w-1/2" />
+                  <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                    {product.title}
+                  </h3>
+
+                  {product.description && (
+                    <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
+                      {product.description}
+                    </p>
+                  )}
+
+                  <div className="flex items-center space-x-2">
+                    <span className="text-lg font-bold text-primary">{formatEUR(currentPrice)}</span>
+                    <span className="text-sm text-muted-foreground line-through">
+                      {formatEUR(oldPrice)}
+                    </span>
+                  </div>
                 </CardContent>
+
+                <CardFooter className="p-4 pt-0 flex gap-2">
+                  <Button asChild className="flex-1 bg-primary hover:bg-primary-light">
+                    <Link to={`/products/${product.slug}`}>Нарачај</Link>
+                  </Button>
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+                  >
+                    <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
+                  </Button>
+                </CardFooter>
               </Card>
-            ))}
-          </div>
-        ) : (
-          <div className="w-full h-full bg-white flex items-center justify-center relative overflow-hidden">
-            {primaryImage ? (
-              <img
-                src={primaryImage}
-                alt={product.title}
-                className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-300"
-                loading="lazy"
-              />
-            ) : (
-              <div className="text-center">
-                <div className="text-4xl mb-2">🌿</div>
-                <p className="text-xs text-muted-foreground">
-                  Слика на производ
-                </p>
-              </div>
-            )}
-          </div>
-
-          // <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-          //   {featuredProducts.map((product) => {
-          //     const currentPrice = Number(product.price) || 0;
-          //     const oldPrice = Math.round(currentPrice * 1.15 * 100) / 100;
-          //     const discount =
-          //       oldPrice > 0
-          //         ? Math.round(((oldPrice - currentPrice) / oldPrice) * 100)
-          //         : 0;
-          //     const primaryImage =
-          //       product.primary_image_url ||
-          //       product.image ||
-          //       product.image_url ||
-          //       null;
-
-          //     return (
-          //       <Card
-          //         key={product.id}
-          //         className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
-          //       >
-          //         <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
-          //           <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
-          //             {primaryImage ? (
-          //               <img
-          //                 src={primaryImage}
-          //                 alt={product.title}
-          //                 className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-          //               />
-          //             ) : (
-          //               <div className="text-center">
-          //                 <div className="text-4xl mb-2">🌿</div>
-          //                 <p className="text-xs text-muted-foreground">
-          //                   Слика на производ
-          //                 </p>
-          //               </div>
-          //             )}
-          //           </div>
-          //           <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
-          //             -{discount}%
-          //           </Badge>
-          //         </div>
-
-          //         <CardContent className="p-4">
-          //           <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
-          //             {product.title}
-          //           </h3>
-
-          //           {product.description && (
-          //             <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
-          //               {product.description}
-          //             </p>
-          //           )}
-
-          //           <div className="flex items-center space-x-2">
-          //             <span className="text-lg font-bold text-primary">
-          //               {formatEUR(currentPrice)}
-          //             </span>
-          //             <span className="text-sm text-muted-foreground line-through">
-          //               {formatEUR(oldPrice)}
-          //             </span>
-          //           </div>
-          //         </CardContent>
-
-          //         <CardFooter className="p-4 pt-0 flex gap-2">
-          //           <Button
-          //             asChild
-          //             className="flex-1 bg-primary hover:bg-primary-light"
-          //           >
-          //             <Link to={`/products/${product.slug}`}>Нарачај</Link>
-          //           </Button>
-          //           <Button
-          //             asChild
-          //             variant="outline"
-          //             className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
-          //           >
-          //             <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
-          //           </Button>
-          //         </CardFooter>
-          //       </Card>
-          //     );
-          //   })}
-          // </div>
-        )}
-
-        {errorMessage && (
-          <div className="text-center text-destructive mb-12">
-            {errorMessage}
-          </div>
-        )}
+            );
+          })}
+        </div>
 
         <div className="text-center">
           <Button

--- a/frontend/src/data/staticProducts.ts
+++ b/frontend/src/data/staticProducts.ts
@@ -1,19 +1,15 @@
-// src/assets/products/mockProducts.ts
-import type { Product } from "@/lib/api";
+import type { Product } from "@/lib/types";
 
-// Import images so Vite resolves URLs correctly
-import imgArthro from "./ArhroVita.jpeg";
-import imgCardi from "./CardiVita.jpeg";
-import imgDia from "./DiaVita.jpeg";
-import imgOpti from "./OptiVita.jpeg";
-import imgPro from "./ProVita.jpeg";
-import imgVitaFit from "./VitaFit.jpeg";
-import imgStallion from "./Stallion Power.jpeg";
+import imgArthro from "@/assets/products/ArhroVita.jpeg";
+import imgCardi from "@/assets/products/CardiVita.jpeg";
+import imgDia from "@/assets/products/DiaVita.jpeg";
+import imgOpti from "@/assets/products/OptiVita.jpeg";
+import imgPro from "@/assets/products/ProVita.jpeg";
 
 const now = new Date();
-const daysAgo = (n: number) => new Date(now.getTime() - n * 86400000).toISOString();
+const daysAgo = (n: number) => new Date(now.getTime() - n * 86_400_000).toISOString();
 
-export const mockProducts: Product[] = [
+export const staticProducts: Product[] = [
   {
     id: "arthrovita",
     title: "ArthroVita – Поддршка за зглобови",
@@ -32,7 +28,7 @@ export const mockProducts: Product[] = [
       "Поддршка за кардиоваскуларно здравје со CoQ10, магнезиум и Б-витамини.",
     price: 21.9,
     primary_image_url: imgCardi,
-    created_at: daysAgo(1),
+    created_at: daysAgo(5),
   },
   {
     id: "diavita",
@@ -42,7 +38,7 @@ export const mockProducts: Product[] = [
       "Билна поддршка за нормални нивоа на гликоза со цимет и берберин.",
     price: 22.5,
     primary_image_url: imgDia,
-    created_at: daysAgo(4),
+    created_at: daysAgo(8),
   },
   {
     id: "optivita",
@@ -52,7 +48,7 @@ export const mockProducts: Product[] = [
       "Лутеин, зеаксантин и боровинка за заштита и удобност на очите.",
     price: 19.9,
     primary_image_url: imgOpti,
-    created_at: daysAgo(7),
+    created_at: daysAgo(11),
   },
   {
     id: "provita",
@@ -62,26 +58,27 @@ export const mockProducts: Product[] = [
       "Цинк, витамин C и D3 за дневна одбрана и енергија.",
     price: 17.9,
     primary_image_url: imgPro,
-    created_at: daysAgo(10),
-  },
-  {
-    id: "vitafit",
-    title: "VitaFit – Дневен мултивитамин",
-    slug: "vitafit",
-    description:
-      "Комплет од 23 нутриенти за тонус и виталност.",
-    price: 15.9,
-    primary_image_url: imgVitaFit,
-    created_at: daysAgo(12),
-  },
-  {
-    id: "stallion-power",
-    title: "Stallion Power – Машка енергија",
-    slug: "stallion-power",
-    description:
-      "Природна формула за сила и издржливост со мака и цинк.",
-    price: 29.9,
-    primary_image_url: imgStallion,
-    created_at: daysAgo(3),
+    created_at: daysAgo(14),
   },
 ];
+
+export function findProductBySlug(slug: string): Product | undefined {
+  return staticProducts.find((product) => product.slug === slug);
+}
+
+export function searchProducts(query?: string): Product[] {
+  if (!query) {
+    return staticProducts;
+  }
+
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return staticProducts;
+  }
+
+  return staticProducts.filter((product) =>
+    `${product.title ?? ""} ${product.description ?? ""} ${product.slug ?? ""}`
+      .toLowerCase()
+      .includes(normalized)
+  );
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -15,8 +15,8 @@ const USE_MOCKS = import.meta.env?.VITE_USE_MOCK_PRODUCTS === "true";
 
 // Lazy import so tree-shaking works nicely
 async function loadMocks(): Promise<Product[]> {
-  const mod = await import("@/assets/products/mockProducts");
-  return mod.mockProducts;
+  const mod = await import("@/data/staticProducts");
+  return mod.staticProducts;
 }
 
 export async function fetchProducts(


### PR DESCRIPTION
## Summary
- add a static catalog of five products with helpers to search and find items locally
- update the products list, detail page, and featured grid to render from the static dataset instead of calling the API
- point the legacy mock loaders at the new dataset so existing fallbacks continue to work

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f7b7acfe4c833098facca9923d720a