### PR TITLE
Add mock product fallback for frontend demo

### DIFF
--- a/frontend/src/assets/products/mockProducts.ts
+++ b/frontend/src/assets/products/mockProducts.ts
@@ -1,7 +1,5 @@
-// src/assets/products/mockProducts.ts
-import type { Product } from "@/lib/api";
+import type { Product } from "@/lib/types";
 
-// Import images so Vite resolves URLs correctly
 import imgArthro from "./ArhroVita.jpeg";
 import imgCardi from "./CardiVita.jpeg";
 import imgDia from "./DiaVita.jpeg";

--- a/frontend/src/components/site/FeaturedGrid.tsx
+++ b/frontend/src/components/site/FeaturedGrid.tsx
@@ -1,12 +1,28 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
+
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { fetchProducts, type Product } from "@/lib/api";
 import { formatEUR } from "@/lib/utils";
-
 import { mockProducts } from "@/assets/products/mockProducts";
+
+const FEATURED_COUNT = 3;
+
+function selectFeaturedProducts(products: Product[]): Product[] {
+  if (!products.length) {
+    return mockProducts.slice(0, FEATURED_COUNT);
+  }
+
+  const sorted = [...products].sort((a, b) => {
+    const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+    const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+    return dateB - dateA;
+  });
+
+  return sorted.slice(0, FEATURED_COUNT);
+}
 
 export function FeaturedGrid() {
   const {
@@ -19,13 +35,10 @@ export function FeaturedGrid() {
     staleTime: 1000 * 60,
   });
 
-  // ✅ Use mock products if API fails or is empty
-  const featuredProducts =
-    !isLoading && products.length > 0 ? products.slice(0, 6) : mockProducts;
+  const featuredProducts = selectFeaturedProducts(products);
 
   const errorMessage =
-    error?.message ||
-    (error ? "Не можеме да ги вчитаме препорачаните производи." : null);
+    error?.message || (error ? "Не можеме да ги вчитаме препорачаните производи." : null);
 
   return (
     <section className="py-16">
@@ -41,7 +54,7 @@ export function FeaturedGrid() {
 
         {isLoading ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-            {[...Array(6)].map((_, index) => (
+            {[...Array(FEATURED_COUNT)].map((_, index) => (
               <Card key={index} className="animate-pulse">
                 <div className="aspect-[4/3] bg-muted" />
                 <CardContent className="p-4">
@@ -53,112 +66,84 @@ export function FeaturedGrid() {
             ))}
           </div>
         ) : (
-          <div className="w-full h-full bg-white flex items-center justify-center relative overflow-hidden">
-            {primaryImage ? (
-              <img
-                src={primaryImage}
-                alt={product.title}
-                className="w-full h-full object-contain group-hover:scale-105 transition-transform duration-300"
-                loading="lazy"
-              />
-            ) : (
-              <div className="text-center">
-                <div className="text-4xl mb-2">🌿</div>
-                <p className="text-xs text-muted-foreground">
-                  Слика на производ
-                </p>
-              </div>
-            )}
-          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
+            {featuredProducts.map((product) => {
+              const currentPrice = Number(product.price) || 0;
+              const oldPrice = Math.round(currentPrice * 1.15 * 100) / 100;
+              const discount =
+                oldPrice > 0 ? Math.round(((oldPrice - currentPrice) / oldPrice) * 100) : 0;
+              const primaryImage =
+                product.primary_image_url || product.image || product.image_url || null;
 
-          // <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-          //   {featuredProducts.map((product) => {
-          //     const currentPrice = Number(product.price) || 0;
-          //     const oldPrice = Math.round(currentPrice * 1.15 * 100) / 100;
-          //     const discount =
-          //       oldPrice > 0
-          //         ? Math.round(((oldPrice - currentPrice) / oldPrice) * 100)
-          //         : 0;
-          //     const primaryImage =
-          //       product.primary_image_url ||
-          //       product.image ||
-          //       product.image_url ||
-          //       null;
+              return (
+                <Card
+                  key={product.id}
+                  className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
+                >
+                  <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
+                    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
+                      {primaryImage ? (
+                        <img
+                          src={primaryImage}
+                          alt={product.title}
+                          className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
+                          loading="lazy"
+                        />
+                      ) : (
+                        <div className="text-center">
+                          <div className="text-4xl mb-2">🌿</div>
+                          <p className="text-xs text-muted-foreground">Слика на производ</p>
+                        </div>
+                      )}
+                    </div>
+                    {discount > 0 && (
+                      <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
+                        -{discount}%
+                      </Badge>
+                    )}
+                  </div>
 
-          //     return (
-          //       <Card
-          //         key={product.id}
-          //         className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
-          //       >
-          //         <div className="aspect-[4/3] bg-gradient-to-br from-primary-lighter/10 to-accent/20 relative overflow-hidden">
-          //           <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-primary/5 to-primary-light/10">
-          //             {primaryImage ? (
-          //               <img
-          //                 src={primaryImage}
-          //                 alt={product.title}
-          //                 className="h-full w-full object-cover group-hover:scale-105 transition-transform duration-300"
-          //               />
-          //             ) : (
-          //               <div className="text-center">
-          //                 <div className="text-4xl mb-2">🌿</div>
-          //                 <p className="text-xs text-muted-foreground">
-          //                   Слика на производ
-          //                 </p>
-          //               </div>
-          //             )}
-          //           </div>
-          //           <Badge className="absolute top-3 left-3 bg-destructive hover:bg-destructive/90">
-          //             -{discount}%
-          //           </Badge>
-          //         </div>
+                  <CardContent className="p-4">
+                    <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                      {product.title}
+                    </h3>
 
-          //         <CardContent className="p-4">
-          //           <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
-          //             {product.title}
-          //           </h3>
+                    {product.description && (
+                      <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
+                        {product.description}
+                      </p>
+                    )}
 
-          //           {product.description && (
-          //             <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
-          //               {product.description}
-          //             </p>
-          //           )}
+                    <div className="flex items-center space-x-2">
+                      <span className="text-lg font-bold text-primary">{formatEUR(currentPrice)}</span>
+                      <span className="text-sm text-muted-foreground line-through">
+                        {formatEUR(oldPrice)}
+                      </span>
+                    </div>
+                  </CardContent>
 
-          //           <div className="flex items-center space-x-2">
-          //             <span className="text-lg font-bold text-primary">
-          //               {formatEUR(currentPrice)}
-          //             </span>
-          //             <span className="text-sm text-muted-foreground line-through">
-          //               {formatEUR(oldPrice)}
-          //             </span>
-          //           </div>
-          //         </CardContent>
-
-          //         <CardFooter className="p-4 pt-0 flex gap-2">
-          //           <Button
-          //             asChild
-          //             className="flex-1 bg-primary hover:bg-primary-light"
-          //           >
-          //             <Link to={`/products/${product.slug}`}>Нарачај</Link>
-          //           </Button>
-          //           <Button
-          //             asChild
-          //             variant="outline"
-          //             className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
-          //           >
-          //             <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
-          //           </Button>
-          //         </CardFooter>
-          //       </Card>
-          //     );
-          //   })}
-          // </div>
-        )}
-
-        {errorMessage && (
-          <div className="text-center text-destructive mb-12">
-            {errorMessage}
+                  <CardFooter className="p-4 pt-0 flex gap-2">
+                    <Button
+                      asChild
+                      className="flex-1 bg-primary hover:bg-primary-light"
+                    >
+                      <Link to={`/products/${product.slug}`}>Нарачај</Link>
+                    </Button>
+                    <Button
+                      asChild
+                      variant="outline"
+                      className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+                    >
+                      <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
+                    </Button>
+                  </CardFooter>
+                </Card>
+              );
+            })}
           </div>
         )}
+
+        {errorMessage && <div className="text-center text-destructive mb-12">{errorMessage}</div>}
 
         <div className="text-center">
           <Button

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -8,76 +8,22 @@ export type Product = {
   image?: string;
   image_url?: string;
   created_at?: string;
-  // add any fields your CartContext expects (e.g., sku, stock, etc.)
 };
 
-const USE_MOCKS = import.meta.env?.VITE_USE_MOCK_PRODUCTS === "true";
+export type OrderItem = {
+  product_id: string;
+  quantity: number;
+  product?: Product;
+};
 
-// Lazy import so tree-shaking works nicely
-async function loadMocks(): Promise<Product[]> {
-  const mod = await import("@/assets/products/mockProducts");
-  return mod.mockProducts;
-}
-
-export async function fetchProducts(
-  search?: string,
-  signal?: AbortSignal
-): Promise<Product[]> {
-  if (USE_MOCKS) {
-    const all = await loadMocks();
-    if (!search) return all;
-    const s = search.toLowerCase();
-    return all.filter((p) =>
-      `${p.title ?? ""} ${p.description ?? ""} ${p.slug ?? ""}`
-        .toLowerCase()
-        .includes(s)
-    );
-  }
-
-  // ---- Real API path (keep your existing code here) ----
-  // Example:
-  const url = new URL("/api/products", window.location.origin);
-  if (search) url.searchParams.set("search", search);
-  const res = await fetch(url.toString(), { signal });
-  if (!res.ok) throw new Error("Грешка при вчитување на производи.");
-  const data: Product[] = await res.json();
-
-  // Fallback: if server returns empty, give mocks (nice for demos)
-  if (!data || data.length === 0) {
-    const all = await loadMocks();
-    if (!search) return all;
-    const s = search.toLowerCase();
-    return all.filter((p) =>
-      `${p.title ?? ""} ${p.description ?? ""} ${p.slug ?? ""}`
-        .toLowerCase()
-        .includes(s)
-    );
-  }
-
-  return data;
-}
-
-export async function fetchProductBySlug(
-  slug: string,
-  signal?: AbortSignal
-): Promise<Product | null> {
-  if (USE_MOCKS) {
-    const all = await loadMocks();
-    return all.find((p) => p.slug === slug) ?? null;
-  }
-
-  // ---- Real API path (keep your existing code here) ----
-  // Example:
-  const url = new URL(`/api/products/${slug}`, window.location.origin);
-  const res = await fetch(url.toString(), { signal });
-  if (res.status === 404) return null;
-  if (!res.ok) throw new Error("Грешка при вчитување на производ.");
-  const product: Product = await res.json();
-
-  // If API returns nothing, try mocks as a safety
-  if (!product) {
-    const all = await loadMocks();
-    return all.find((p) => p.slug === slug) ?? null;
-  }
-  return product;
-}
+export type Order = {
+  id: string;
+  status?: string;
+  created_at?: string;
+  customer_name?: string;
+  customer_phone?: string;
+  customer_email?: string | null;
+  customer_address?: string | null;
+  notes?: string | null;
+  items?: OrderItem[];
+};


### PR DESCRIPTION
## Summary
- add mock product fallback and simulated order confirmation when the API is offline
- simplify shared product and order types and update mock product imports
- rebuild the featured grid to render real cards from the sample products

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f9183902288330a98d2d7d11d7065d