### PR TITLE
Add scroll reveal animations and clean console usage

### DIFF
--- a/frontend/src/components/animations/ScrollReveal.tsx
+++ b/frontend/src/components/animations/ScrollReveal.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useRef, type ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface ScrollRevealProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+  delay?: number;
+  once?: boolean;
+}
+
+export function ScrollReveal({
+  children,
+  className,
+  delay = 0,
+  once = true,
+  style,
+  ...rest
+}: ScrollRevealProps) {
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const node = elementRef.current;
+    if (!node) {
+      return undefined;
+    }
+
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const prefersReducedMotion =
+      window.matchMedia &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    if (prefersReducedMotion) {
+      node.classList.add("reveal-visible");
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("reveal-visible");
+            if (once) {
+              observer.unobserve(entry.target);
+            }
+          } else if (!once) {
+            entry.target.classList.remove("reveal-visible");
+          }
+        });
+      },
+      {
+        threshold: 0.15,
+        rootMargin: "0px 0px -10% 0px",
+      }
+    );
+
+    observer.observe(node);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [once]);
+
+  return (
+    <div
+      ref={elementRef}
+      className={cn("reveal-init", className)}
+      style={{ ...style, transitionDelay: `${delay}ms` }}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/site/ContactBlock.tsx
+++ b/frontend/src/components/site/ContactBlock.tsx
@@ -1,4 +1,6 @@
 import { MapPin, Phone, Mail, Facebook, Instagram } from "lucide-react";
+
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
@@ -6,73 +8,56 @@ export function ContactBlock() {
   return (
     <section className="py-16 bg-gradient-to-b from-accent/10 to-background">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <ScrollReveal className="text-center mb-12">
           <p className="text-lg text-muted-foreground">
             Секогаш сме тука за вас - за било какви прашања или совети
           </p>
-        </div>
+        </ScrollReveal>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {/* Address */}
-          <Card className="text-center hover:shadow-md transition-shadow border-border/50">
-            <CardContent className="p-6">
-              <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
-                <MapPin className="w-6 h-6 text-primary" />
-              </div>
-              <h3 className="font-semibold text-foreground mb-2 uppercase tracking-wide">
-                Адреса
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                ул. Природа бр. 123
-                <br />
-                1000 Скопје, Македонија
-              </p>
-            </CardContent>
-          </Card>
-
-          {/* Phone */}
-          <Card className="text-center hover:shadow-md transition-shadow border-border/50">
-            <CardContent className="p-6">
-              <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
-                <Phone className="w-6 h-6 text-primary" />
-              </div>
-              <h3 className="font-semibold text-foreground mb-2 uppercase tracking-wide">
-                Телефон
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                <a
-                  href="tel:+38970123456"
-                  className="hover:text-primary transition-colors"
-                >
-                  +389 70 123 456
-                </a>
-              </p>
-            </CardContent>
-          </Card>
-
-          {/* Email */}
-          <Card className="text-center hover:shadow-md transition-shadow border-border/50">
-            <CardContent className="p-6">
-              <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
-                <Mail className="w-6 h-6 text-primary" />
-              </div>
-              <h3 className="font-semibold text-foreground mb-2 uppercase tracking-wide">
-                Е-пошта
-              </h3>
-              <p className="text-sm text-muted-foreground">
-                <a
-                  href="mailto:info@vitacall.mk"
-                  className="hover:text-primary transition-colors"
-                >
-                  info@vitacall.mk
-                </a>
-              </p>
-            </CardContent>
-          </Card>
+          {[MapPin, Phone, Mail].map((IconComponent, index) => (
+            <ScrollReveal key={IconComponent.displayName || index} delay={index * 120}>
+              <Card className="text-center hover:shadow-md transition-shadow border-border/50">
+                <CardContent className="p-6">
+                  <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4">
+                    <IconComponent className="w-6 h-6 text-primary" />
+                  </div>
+                  <h3 className="font-semibold text-foreground mb-2 uppercase tracking-wide">
+                    {index === 0 ? "Адреса" : index === 1 ? "Телефон" : "Е-пошта"}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {index === 0 && (
+                      <>
+                        ул. Природа бр. 123
+                        <br />
+                        1000 Скопје, Македонија
+                      </>
+                    )}
+                    {index === 1 && (
+                      <a
+                        href="tel:+38970123456"
+                        className="hover:text-primary transition-colors"
+                      >
+                        +389 70 123 456
+                      </a>
+                    )}
+                    {index === 2 && (
+                      <a
+                        href="mailto:info@vitacall.mk"
+                        className="hover:text-primary transition-colors"
+                      >
+                        info@vitacall.mk
+                      </a>
+                    )}
+                  </p>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
+          ))}
         </div>
 
         {/* Social Media */}
-        <div className="text-center mt-12">
+        <ScrollReveal className="text-center mt-12">
           <h3 className="text-lg font-semibold text-foreground mb-4 uppercase tracking-wide">
             Следете не
           </h3>
@@ -92,7 +77,7 @@ export function ContactBlock() {
               <Instagram className="w-5 h-5" />
             </Button>
           </div>
-        </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/frontend/src/components/site/FeaturedGrid.tsx
+++ b/frontend/src/components/site/FeaturedGrid.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -44,14 +45,14 @@ export function FeaturedGrid() {
   return (
     <section className="py-16">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+        <ScrollReveal className="text-center mb-12 space-y-4">
+          <h2 className="text-3xl md:text-4xl font-bold text-foreground">
             Препорачани производи
           </h2>
           <p className="text-lg text-muted-foreground">
             Откријте ги нашите најпопуларни природни решенија
           </p>
-        </div>
+        </ScrollReveal>
 
         {isLoading ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
@@ -68,7 +69,7 @@ export function FeaturedGrid() {
           </div>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-            {featuredProducts.map((product) => {
+            {featuredProducts.map((product, index) => {
               const currentPrice = Number(product.price) || 0;
               const oldPrice = Number((product as any).original_price) || 4800;
               const discount =
@@ -80,17 +81,16 @@ export function FeaturedGrid() {
                 product.image ||
                 product.image_url ||
                 null;
-
               return (
-                <Card
-                  key={product.id}
-                  className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
-                >
-                  <div className="aspect-[4/3] relative overflow-hidden bg-transparent">
-                    <div className="w-full h-full flex items-center justify-center bg-transparent p-2 sm:p-3 md:p-4">
-                      {primaryImage ? (
-                        <img
-                          src={primaryImage}
+                <ScrollReveal key={product.id} delay={index * 100} className="h-full">
+                  <Card
+                    className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20 h-full"
+                  >
+                    <div className="aspect-[4/3] relative overflow-hidden bg-transparent">
+                      <div className="w-full h-full flex items-center justify-center bg-transparent p-2 sm:p-3 md:p-4">
+                        {primaryImage ? (
+                          <img
+                            src={primaryImage}
                           alt={product.title}
                           className="h-full w-full object-contain"
                           loading="lazy"
@@ -111,43 +111,44 @@ export function FeaturedGrid() {
                     )}
                   </div>
 
-                  <CardContent className="p-4">
-                    <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
-                      {product.title}
-                    </h3>
+                    <CardContent className="p-4">
+                      <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                        {product.title}
+                      </h3>
 
-                    {product.description && (
-                      <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
-                        {product.description}
-                      </p>
-                    )}
+                      {product.description && (
+                        <p className="text-sm text-muted-foreground mb-3 line-clamp-3">
+                          {product.description}
+                        </p>
+                      )}
 
-                    <div className="flex items-center space-x-2">
-                      <span className="text-lg font-bold text-primary">
-                        {formatEUR(currentPrice)}
-                      </span>
-                      <span className="text-sm text-muted-foreground line-through">
-                        {formatEUR(oldPrice)}
-                      </span>
-                    </div>
-                  </CardContent>
+                      <div className="flex items-center space-x-2">
+                        <span className="text-lg font-bold text-primary">
+                          {formatEUR(currentPrice)}
+                        </span>
+                        <span className="text-sm text-muted-foreground line-through">
+                          {formatEUR(oldPrice)}
+                        </span>
+                      </div>
+                    </CardContent>
 
-                  <CardFooter className="p-4 pt-0 flex gap-2">
-                    <Button
-                      asChild
-                      className="flex-1 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold"
-                    >
-                      <Link to={`/products/${product.slug}`}>Нарачај</Link>
-                    </Button>
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
-                    >
-                      <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
-                    </Button>
-                  </CardFooter>
-                </Card>
+                    <CardFooter className="p-4 pt-0 flex gap-2">
+                      <Button
+                        asChild
+                        className="flex-1 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold"
+                      >
+                        <Link to={`/products/${product.slug}`}>Нарачај</Link>
+                      </Button>
+                      <Button
+                        asChild
+                        variant="outline"
+                        className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+                      >
+                        <Link to={`/products/${product.slug}`}>Повеќе инфо</Link>
+                      </Button>
+                    </CardFooter>
+                  </Card>
+                </ScrollReveal>
               );
             })}
           </div>
@@ -159,7 +160,7 @@ export function FeaturedGrid() {
           </div>
         )}
 
-        <div className="text-center">
+        <ScrollReveal className="text-center">
           <Button
             asChild
             size="lg"
@@ -168,7 +169,7 @@ export function FeaturedGrid() {
           >
             <Link to="/products">Видете ги сите производи</Link>
           </Button>
-        </div>
+        </ScrollReveal>
       </div>
     </section>
   );

--- a/frontend/src/components/site/Hero.tsx
+++ b/frontend/src/components/site/Hero.tsx
@@ -1,4 +1,5 @@
 import { Link } from "react-router-dom";
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Button } from "@/components/ui/button";
 
 export function Hero() {
@@ -6,29 +7,38 @@ export function Hero() {
     <section className="relative py-20 lg:py-28 flex items-center justify-center text-center overflow-hidden">
       {/* soft gradient background */}
       <div className="absolute inset-0 bg-gradient-to-br from-accent/30 to-background" />
+      <div className="hero-backdrop">
+        <div className="hero-blob" />
+        <div className="hero-blob" />
+        <div className="hero-blob" />
+      </div>
 
       {/* centered content */}
-      <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-center justify-center">
-        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-6 font-[var(--font-script)]">
+      <ScrollReveal className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col items-center justify-center space-y-6">
+        <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground font-[var(--font-script)]">
           <span className="text-primary">Додатоци во исхраната</span>
           <br />
           <span className="text-muted-foreground">и природни креми</span>
         </h1>
 
-        <p className="text-lg md:text-xl text-muted-foreground mb-8 max-w-2xl leading-relaxed">
-          Внимателно одбрани билни мешавини наменети за зајакнување на
-          имунолошкиот систем, балансирање на метаболизмот и природна помош за
-          вашата кожа и коса.
-        </p>
+        <ScrollReveal delay={120} className="w-full">
+          <p className="text-lg md:text-xl text-muted-foreground max-w-2xl mx-auto leading-relaxed">
+            Внимателно одбрани билни мешавини наменети за зајакнување на
+            имунолошкиот систем, балансирање на метаболизмот и природна помош за
+            вашата кожа и коса.
+          </p>
+        </ScrollReveal>
 
-        <Button
-          asChild
-          size="lg"
-          className="bg-gradient-to-r from-primary to-primary-light hover:from-primary-light hover:to-primary shadow-md hover:shadow-lg transition-all duration-300"
-        >
-          <Link to="/products">ПРОИЗВОДИ</Link>
-        </Button>
-      </div>
+        <ScrollReveal delay={240} className="flex justify-center">
+          <Button
+            asChild
+            size="lg"
+            className="bg-gradient-to-r from-primary to-primary-light hover:from-primary-light hover:to-primary shadow-md hover:shadow-xl transition-all duration-500"
+          >
+            <Link to="/products">ПРОИЗВОДИ</Link>
+          </Button>
+        </ScrollReveal>
+      </ScrollReveal>
     </section>
   );
 }

--- a/frontend/src/components/site/QuickOrderDialog.tsx
+++ b/frontend/src/components/site/QuickOrderDialog.tsx
@@ -118,7 +118,9 @@ export function QuickOrderDialog({ product, trigger }: QuickOrderDialogProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="max-w-md">
+      <DialogContent
+        className="max-w-md data-[state=open]:animate-in data-[state=open]:fade-in-90 data-[state=open]:zoom-in-95 data-[state=open]:duration-300 data-[state=open]:ease-out data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
+      >
         <DialogHeader>
           <DialogTitle>Нарачај {product.title}</DialogTitle>
           <DialogDescription>
@@ -129,13 +131,13 @@ export function QuickOrderDialog({ product, trigger }: QuickOrderDialogProps) {
 
         <ScrollArea className="max-h-[70vh] pr-4">
           <div className="space-y-4 py-1">
-            <div className="flex items-center gap-4 rounded-lg border border-border/60 bg-muted/20 p-4">
+            <div className="group flex items-center gap-4 rounded-lg border border-border/60 bg-muted/20 p-4 transition-transform duration-300 ease-out">
               {primaryImage ? (
-                <div className="relative h-16 w-16 overflow-hidden rounded-md bg-background">
+                <div className="relative h-16 w-16 overflow-hidden rounded-md bg-background shadow-sm">
                   <img
                     src={primaryImage}
                     alt={product.title}
-                    className="absolute inset-0 h-full w-full object-contain"
+                    className="absolute inset-0 h-full w-full object-contain transition-transform duration-500 group-hover:scale-105"
                   />
                 </div>
               ) : (

--- a/frontend/src/components/site/StatsBand.tsx
+++ b/frontend/src/components/site/StatsBand.tsx
@@ -1,3 +1,5 @@
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
+
 const stats = [
   { value: "4+", label: "години искуство", description: "во природната медицина" },
   { value: "56k+", label: "нарачки", description: "задоволни купувачи" },
@@ -10,21 +12,21 @@ export function StatsBand() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 text-center">
           {stats.map((stat, index) => (
-            <div key={index} className="group">
+            <ScrollReveal key={index} delay={index * 100} className="group">
               <div className="mb-2">
                 <span className="text-4xl md:text-5xl font-bold text-primary group-hover:text-primary-light transition-colors">
                   {stat.value}
                 </span>
               </div>
-              
+
               <h3 className="text-lg md:text-xl font-semibold text-foreground uppercase tracking-wide mb-1">
                 {stat.label}
               </h3>
-              
+
               <p className="text-sm text-muted-foreground">
                 {stat.description}
               </p>
-            </div>
+            </ScrollReveal>
           ))}
         </div>
       </div>

--- a/frontend/src/components/site/ValueProps.tsx
+++ b/frontend/src/components/site/ValueProps.tsx
@@ -1,4 +1,6 @@
 import { Shield, Leaf, Award, CreditCard } from "lucide-react";
+
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Card } from "@/components/ui/card";
 
 const valueProps = [
@@ -32,32 +34,33 @@ export function ValueProps() {
   return (
     <section className="py-16 bg-gradient-to-b from-background to-accent/20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-12">
+        <ScrollReveal className="text-center mb-12">
           <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
             Нашите вредности и ангажман кон квалитет и транспарентност
           </p>
-        </div>
+        </ScrollReveal>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {valueProps.map((prop, index) => {
             const Icon = prop.icon;
             return (
-              <Card
-                key={index}
-                className="p-6 text-center hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20 group"
-              >
-                <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4 group-hover:bg-primary/20 transition-colors">
-                  <Icon className="w-8 h-8 text-primary" />
-                </div>
+              <ScrollReveal key={index} delay={index * 80} className="h-full">
+                <Card
+                  className="p-6 text-center hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20 group h-full"
+                >
+                  <div className="w-16 h-16 rounded-full bg-primary/10 flex items-center justify-center mx-auto mb-4 group-hover:bg-primary/20 transition-colors">
+                    <Icon className="w-8 h-8 text-primary" />
+                  </div>
 
-                <h3 className="text-lg font-semibold text-foreground mb-2 uppercase tracking-wide">
-                  {prop.title}
-                </h3>
+                  <h3 className="text-lg font-semibold text-foreground mb-2 uppercase tracking-wide">
+                    {prop.title}
+                  </h3>
 
-                <p className="text-sm text-muted-foreground leading-relaxed">
-                  {prop.description}
-                </p>
-              </Card>
+                  <p className="text-sm text-muted-foreground leading-relaxed">
+                    {prop.description}
+                  </p>
+                </Card>
+              </ScrollReveal>
             );
           })}
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -127,6 +127,10 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  html {
+    scroll-behavior: smooth;
+  }
 }
 
 /* Responsive helpers for 1000px breakpoint without changing Tailwind config */
@@ -145,4 +149,79 @@ input[type="search"]::-webkit-search-results-decoration {
 @media (max-width: 999.98px) {
   .show-desktop-1000 { display: none !important; }
   .hide-desktop-1000 { display: inline-flex !important; }
+}
+
+.reveal-init {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.7s cubic-bezier(0.22, 1, 0.36, 1),
+    transform 0.7s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
+}
+
+.reveal-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-init {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+.hero-backdrop {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.hero-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(80px);
+  opacity: 0.5;
+  animation: float-slow 16s ease-in-out infinite;
+}
+
+.hero-blob:nth-child(1) {
+  background: radial-gradient(circle at center, hsl(82 39% 45% / 0.7), transparent 65%);
+  width: 320px;
+  height: 320px;
+  top: -60px;
+  left: -40px;
+}
+
+.hero-blob:nth-child(2) {
+  background: radial-gradient(circle at center, hsl(45 80% 65% / 0.6), transparent 70%);
+  width: 280px;
+  height: 280px;
+  bottom: -80px;
+  right: -60px;
+  animation-delay: 3s;
+}
+
+.hero-blob:nth-child(3) {
+  background: radial-gradient(circle at center, hsl(192 70% 80% / 0.45), transparent 70%);
+  width: 260px;
+  height: 260px;
+  top: 40%;
+  left: 50%;
+  transform: translateX(-50%);
+  animation-delay: 6s;
+}
+
+@keyframes float-slow {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(12px, -24px, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-12px, 16px, 0) scale(1);
+  }
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -52,9 +52,9 @@ export async function fetchProducts(search?: string, signal?: AbortSignal): Prom
       return data;
     }
 
-    console.warn("Product API returned no data. Falling back to mock products.");
+    // Fall back to mock products when the API returns an empty result set.
   } catch (error) {
-    console.warn("Failed to load products from API. Falling back to mock products.", error);
+    // Fall back to mock products if the API request fails.
   }
 
   const fallback = sampleMockProducts(search);
@@ -70,7 +70,7 @@ export async function fetchProductBySlug(slug: string, signal?: AbortSignal): Pr
     const response = await fetch(`${API_BASE_URL}/api/products/${slug}`, { signal });
 
     if (response.status === 404) {
-      console.warn(`Product with slug "${slug}" not found on API. Falling back to mock data.`);
+      // Fall through to mock data when the product is not found via the API.
     } else if (!response.ok) {
       const text = await response.text();
       const detail = text ? (JSON.parse(text) as { detail?: string }).detail : null;
@@ -82,7 +82,7 @@ export async function fetchProductBySlug(slug: string, signal?: AbortSignal): Pr
       }
     }
   } catch (error) {
-    console.warn(`Failed to load product "${slug}" from API. Using mock product if available.`, error);
+    // Fall back to mock data when the API request fails.
   }
 
   return mockProducts.find((product) => product.slug === slug) ?? null;
@@ -145,7 +145,7 @@ export async function submitOrderRequest(payload: OrderRequestPayload): Promise<
       body: JSON.stringify(buildOrderBody(payload)),
     });
   } catch (error) {
-    console.warn("Failed to submit order to API. Returning mock confirmation instead.", error);
+    // Provide a mock confirmation if the API submission fails.
     return buildMockOrder(payload);
   }
 }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,5 +1,6 @@
 import { Navbar } from "@/components/site/Navbar";
 import { Footer } from "@/components/site/Footer";
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 
@@ -48,7 +49,7 @@ export default function AboutPage() {
       <Navbar />
       <main className="flex-1">
         <section className="bg-gradient-to-b from-accent/20 to-background py-16">
-          <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
+          <ScrollReveal className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
             <Badge
               variant="secondary"
               className="uppercase tracking-wide text-primary"
@@ -64,12 +65,12 @@ export default function AboutPage() {
               благосостојба. Нашата мисија е да внесеме моменти на грижа и
               радост во секојдневните ритуали.
             </p>
-          </div>
+          </ScrollReveal>
         </section>
 
         <section className="py-16">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 grid gap-8 md:grid-cols-2">
-            <div className="space-y-6">
+            <ScrollReveal className="space-y-6">
               <h2 className="text-2xl md:text-3xl font-semibold">
                 Нашиот пристап
               </h2>
@@ -86,20 +87,22 @@ export default function AboutPage() {
                 развој за да понудиме нови решенија засновани на современи
                 научни сознанија и традиционални рецепти.
               </p>
-            </div>
+            </ScrollReveal>
 
             <div className="grid gap-4">
-              {values.map((value) => (
-                <Card key={value.title} className="border-border/60">
-                  <CardContent className="p-6 space-y-2 text-left">
-                    <h3 className="text-xl font-semibold text-foreground">
-                      {value.title}
-                    </h3>
-                    <p className="text-muted-foreground leading-relaxed">
-                      {value.description}
-                    </p>
-                  </CardContent>
-                </Card>
+              {values.map((value, index) => (
+                <ScrollReveal key={value.title} delay={index * 120}>
+                  <Card className="border-border/60">
+                    <CardContent className="p-6 space-y-2 text-left">
+                      <h3 className="text-xl font-semibold text-foreground">
+                        {value.title}
+                      </h3>
+                      <p className="text-muted-foreground leading-relaxed">
+                        {value.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                </ScrollReveal>
               ))}
             </div>
           </div>
@@ -107,25 +110,26 @@ export default function AboutPage() {
 
         <section className="bg-muted/30 py-16">
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl md:text-3xl font-semibold text-center mb-10">
-              Клучни моменти
-            </h2>
+            <ScrollReveal className="text-center mb-10">
+              <h2 className="text-2xl md:text-3xl font-semibold">
+                Клучни моменти
+              </h2>
+            </ScrollReveal>
             <div className="grid gap-6 md:grid-cols-3">
-              {milestones.map((milestone) => (
-                <Card
-                  key={milestone.year}
-                  className="border-border/60 text-center"
-                >
-                  <CardContent className="p-6 space-y-3">
-                    <span className="text-sm font-semibold uppercase tracking-wide text-primary">
-                      {milestone.year}
-                    </span>
-                    <h3 className="text-xl font-semibold">{milestone.title}</h3>
-                    <p className="text-muted-foreground leading-relaxed">
-                      {milestone.description}
-                    </p>
-                  </CardContent>
-                </Card>
+              {milestones.map((milestone, index) => (
+                <ScrollReveal key={milestone.year} delay={index * 120}>
+                  <Card className="border-border/60 text-center">
+                    <CardContent className="p-6 space-y-3">
+                      <span className="text-sm font-semibold uppercase tracking-wide text-primary">
+                        {milestone.year}
+                      </span>
+                      <h3 className="text-xl font-semibold">{milestone.title}</h3>
+                      <p className="text-muted-foreground leading-relaxed">
+                        {milestone.description}
+                      </p>
+                    </CardContent>
+                  </Card>
+                </ScrollReveal>
               ))}
             </div>
           </div>

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -1,6 +1,7 @@
 import { Navbar } from "@/components/site/Navbar";
 import { Footer } from "@/components/site/Footer";
 import { ContactBlock } from "@/components/site/ContactBlock";
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -12,7 +13,7 @@ export default function ContactPage() {
       <Navbar />
       <main className="flex-1">
         <section className="py-16">
-          <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-4">
+          <ScrollReveal className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-4">
             <h1 className="text-3xl md:text-4xl font-bold text-foreground">
               Контактирајте го тимот на Vita Call
             </h1>
@@ -20,18 +21,19 @@ export default function ContactPage() {
               Имаме отворена комуникација со нашите клиенти. Пополнете ја
               формата и ќе ви одговориме во рок од 24 часа.
             </p>
-          </div>
+          </ScrollReveal>
         </section>
 
         <section className="py-8">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 grid gap-8 md:grid-cols-[2fr,3fr]">
-            <Card className="border-border/60">
-              <CardContent className="p-6 space-y-4 text-left">
-                <h2 className="text-2xl font-semibold text-foreground">
-                  Работно време
-                </h2>
-                <p className="text-muted-foreground">
-                  Понеделник - Петок: 09:00 - 18:00
+            <ScrollReveal>
+              <Card className="border-border/60 h-full">
+                <CardContent className="p-6 space-y-4 text-left">
+                  <h2 className="text-2xl font-semibold text-foreground">
+                    Работно време
+                  </h2>
+                  <p className="text-muted-foreground">
+                    Понеделник - Петок: 09:00 - 18:00
                   <br />
                   Сабота: 10:00 - 14:00
                 </p>
@@ -62,26 +64,28 @@ export default function ContactPage() {
                   <h3 className="text-lg font-semibold text-foreground">
                     Е-пошта
                   </h3>
-                  <p>
-                    <a
-                      href="mailto:info@naturalcharm.mk"
-                      className="text-primary hover:text-primary-light"
-                    >
-                      info@naturalcharm.mk
-                    </a>
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+                    <p>
+                      <a
+                        href="mailto:info@naturalcharm.mk"
+                        className="text-primary hover:text-primary-light"
+                      >
+                        info@naturalcharm.mk
+                      </a>
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
 
-            <Card className="border-border/60">
-              <CardContent className="p-6">
-                <form className="space-y-4">
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <label
-                        htmlFor="contact-name"
-                        className="block text-sm font-medium text-foreground"
+            <ScrollReveal delay={160}>
+              <Card className="border-border/60">
+                <CardContent className="p-6">
+                  <form className="space-y-4">
+                    <div className="grid gap-4 md:grid-cols-2">
+                      <div className="space-y-2">
+                        <label
+                          htmlFor="contact-name"
+                          className="block text-sm font-medium text-foreground"
                       >
                         Име и презиме
                       </label>
@@ -131,13 +135,14 @@ export default function ContactPage() {
                   </div>
                   <Button
                     type="submit"
-                    className="w-full bg-primary hover:bg-primary-light"
+                    className="w-full bg-primary hover:bg-primary-light transition-colors duration-300"
                   >
                     Испрати порака
                   </Button>
-                </form>
-              </CardContent>
-            </Card>
+                  </form>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
           </div>
         </section>
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,14 +1,9 @@
-import { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Navbar } from "@/components/site/Navbar";
 import { Footer } from "@/components/site/Footer";
 
 const NotFound = () => {
   const location = useLocation();
-
-  useEffect(() => {
-    console.error("404 Error: User attempted to access non-existent route:", location.pathname);
-  }, [location.pathname]);
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground">

--- a/frontend/src/pages/ProductDetailPage.tsx
+++ b/frontend/src/pages/ProductDetailPage.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { Navbar } from "@/components/site/Navbar";
 import { Footer } from "@/components/site/Footer";
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -61,7 +62,6 @@ export default function ProductDetailPage() {
       return;
     }
 
-    console.error("Error loading product:", error);
     toast({
       position: "center",
       title: "Грешка",
@@ -138,20 +138,22 @@ export default function ProductDetailPage() {
       <Navbar />
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Button asChild variant="ghost" className="mb-4">
-          <Link to="/products" className="flex items-center gap-2">
-            <ArrowLeft className="h-4 w-4" />
-            Назад кон производи
-          </Link>
-        </Button>
+        <ScrollReveal className="mb-4 inline-flex">
+          <Button asChild variant="ghost">
+            <Link to="/products" className="flex items-center gap-2">
+              <ArrowLeft className="h-4 w-4" />
+              Назад кон производи
+            </Link>
+          </Button>
+        </ScrollReveal>
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
-          <div className="aspect-square rounded-lg overflow-hidden bg-transparent p-2 sm:p-4 md:p-6">
+          <ScrollReveal className="aspect-square rounded-lg overflow-hidden bg-transparent p-2 sm:p-4 md:p-6">
             {primaryImage ? (
               <img
                 src={primaryImage}
                 alt={product.title}
-                className="w-full h-full object-contain"
+                className="w-full h-full object-contain transition-transform duration-700 ease-out hover:scale-105"
               />
             ) : (
               <div className="w-full h-full flex items-center justify-center">
@@ -161,9 +163,9 @@ export default function ProductDetailPage() {
                 </div>
               </div>
             )}
-          </div>
+          </ScrollReveal>
 
-          <div className="space-y-6">
+          <ScrollReveal className="space-y-6">
             <div>
               <h1 className="text-3xl font-bold text-foreground mb-4">
                 {product.title}
@@ -183,40 +185,42 @@ export default function ProductDetailPage() {
               )}
             </div>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>Нарачај сега - Плати при достава</CardTitle>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <p className="text-sm text-muted-foreground">
-                  Оставете ги вашите податоци во формата и нашиот тим ќе ве
-                  контактира за да ја потврди нарачката и да договори достава.
-                </p>
+            <ScrollReveal delay={120}>
+              <Card>
+                <CardHeader>
+                  <CardTitle>Нарачај сега - Плати при достава</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <p className="text-sm text-muted-foreground">
+                    Оставете ги вашите податоци во формата и нашиот тим ќе ве
+                    контактира за да ја потврди нарачката и да договори достава.
+                  </p>
 
-                <Badge
-                  variant="outline"
-                  className="w-fit border-primary text-primary bg-primary/5"
-                >
-                  Плаќање при достава
-                </Badge>
+                  <Badge
+                    variant="outline"
+                    className="w-fit border-primary text-primary bg-primary/5"
+                  >
+                    Плаќање при достава
+                  </Badge>
 
-                <QuickOrderDialog
-                  product={product}
-                  trigger={
-                    <Button className="w-full h-12 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold">
-                      <ShoppingCart className="mr-2 h-4 w-4" />
-                      Нарачај
-                    </Button>
-                  }
-                />
+                  <QuickOrderDialog
+                    product={product}
+                    trigger={
+                      <Button className="w-full h-12 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold transition-colors duration-300">
+                        <ShoppingCart className="mr-2 h-4 w-4" />
+                        Нарачај
+                      </Button>
+                    }
+                  />
 
-                <p className="text-xs text-muted-foreground">
-                  * Вашите податоци ги користиме само за да ја потврдиме
-                  нарачката. Можете да се предомислите при телефонската потврда.
-                </p>
-              </CardContent>
-            </Card>
-          </div>
+                  <p className="text-xs text-muted-foreground">
+                    * Вашите податоци ги користиме само за да ја потврдиме
+                    нарачката. Можете да се предомислите при телефонската потврда.
+                  </p>
+                </CardContent>
+              </Card>
+            </ScrollReveal>
+          </ScrollReveal>
         </div>
       </main>
 

--- a/frontend/src/pages/ProductsPage.tsx
+++ b/frontend/src/pages/ProductsPage.tsx
@@ -4,6 +4,7 @@ import { Grid, List, ShoppingCart } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Navbar } from "@/components/site/Navbar";
 import { Footer } from "@/components/site/Footer";
+import { ScrollReveal } from "@/components/animations/ScrollReveal";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -89,17 +90,17 @@ export default function ProductsPage() {
 
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Header */}
-        <div className="mb-8">
-          <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+        <ScrollReveal className="mb-8 space-y-4">
+          <h1 className="text-3xl md:text-4xl font-bold text-foreground">
             Производи
           </h1>
           <p className="text-lg text-muted-foreground">
             Откријте ги сите наши природни решенија за здравје и убавина
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Filters - hidden on mobile for simpler UX */}
-        <div className="hidden md:flex flex-col lg:flex-row gap-4 mb-8 p-6 bg-muted/20 rounded-lg">
+        <ScrollReveal className="hidden md:flex flex-col lg:flex-row gap-4 mb-8 p-6 bg-muted/20 rounded-lg">
           <Select value={sortBy} onValueChange={setSortBy}>
             <SelectTrigger className="w-full lg:w-48">
               <SelectValue placeholder="Сортирај по" />
@@ -130,10 +131,10 @@ export default function ProductsPage() {
               <List className="h-4 w-4" />
             </Button>
           </div>
-        </div>
+        </ScrollReveal>
 
         {/* Results count */}
-        <div className="mb-6">
+        <ScrollReveal className="mb-6">
           <p className="text-sm text-muted-foreground">
             {isLoading
               ? "Се вчитува..."
@@ -145,7 +146,7 @@ export default function ProductsPage() {
               ? `Нема производи за "${searchQuery}"`
               : "Нема достапни производи"}
           </p>
-        </div>
+        </ScrollReveal>
 
         {/* Products Grid/List */}
         {isLoading ? (
@@ -169,7 +170,7 @@ export default function ProductsPage() {
                 : "space-y-4"
             }
           >
-            {sortedProducts.map((product) => {
+            {sortedProducts.map((product, index) => {
               const primaryImage =
                 product.primary_image_url ||
                 product.image ||
@@ -177,87 +178,86 @@ export default function ProductsPage() {
                 null;
 
               return (
-                <Card
-                  key={product.id}
-                  className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20"
-                >
-                  <div
-                    className={
-                      viewMode === "grid"
-                        ? "aspect-[4/3]"
-                        : "aspect-[4/3] lg:aspect-[2/1]"
-                    }
-                  >
-                    <div className="w-full h-full bg-transparent flex items-center justify-center relative overflow-hidden p-2 sm:p-3 md:p-4">
-                      {primaryImage ? (
-                        <img
-                          src={primaryImage}
-                          alt={product.title}
-                          className="w-full h-full object-contain"
-                        />
-                      ) : (
-                        <div className="text-center">
-                          <div className="text-4xl mb-2">🌿</div>
-                          <p className="text-xs text-muted-foreground">
-                            Слика на производ
-                          </p>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-
-                  <CardContent className="p-4">
-                    <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
-                      {product.title}
-                    </h3>
-
-                    {product.description && (
-                      <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
-                        {product.description}
-                      </p>
-                    )}
-
-                    <div className="flex items-center justify-between">
-                      <span className="text-lg font-bold text-primary">
-                        {formatEUR(Number(product.price) || 0)}
-                      </span>
-                      <span className="text-sm text-muted-foreground line-through">
-                        {formatEUR(
-                          Number((product as any).original_price) || 4800
-                        )}
-                      </span>
-                    </div>
-                  </CardContent>
-
-                  <CardFooter className="p-4 pt-0 flex gap-2">
-                    <QuickOrderDialog
-                      product={product}
-                      trigger={
-                        <Button className="flex-1 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold">
-                          <ShoppingCart className="mr-2 h-4 w-4" />
-                          Нарачај
-                        </Button>
+                <ScrollReveal key={product.id} delay={index * 60} className="h-full">
+                  <Card className="group overflow-hidden hover:shadow-lg transition-all duration-300 border-border/50 hover:border-primary/20 h-full">
+                    <div
+                      className={
+                        viewMode === "grid"
+                          ? "aspect-[4/3]"
+                          : "aspect-[4/3] lg:aspect-[2/1]"
                       }
-                    />
-
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
                     >
-                      <Link to={`/products/${product.slug}`}>Детали</Link>
-                    </Button>
-                  </CardFooter>
-                </Card>
+                      <div className="w-full h-full bg-transparent flex items-center justify-center relative overflow-hidden p-2 sm:p-3 md:p-4">
+                        {primaryImage ? (
+                          <img
+                            src={primaryImage}
+                            alt={product.title}
+                            className="w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
+                          />
+                        ) : (
+                          <div className="text-center">
+                            <div className="text-4xl mb-2">🌿</div>
+                            <p className="text-xs text-muted-foreground">
+                              Слика на производ
+                            </p>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <CardContent className="p-4">
+                      <h3 className="font-semibold text-foreground mb-2 group-hover:text-primary transition-colors line-clamp-2">
+                        {product.title}
+                      </h3>
+
+                      {product.description && (
+                        <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+                          {product.description}
+                        </p>
+                      )}
+
+                      <div className="flex items-center justify-between">
+                        <span className="text-lg font-bold text-primary">
+                          {formatEUR(Number(product.price) || 0)}
+                        </span>
+                        <span className="text-sm text-muted-foreground line-through">
+                          {formatEUR(
+                            Number((product as any).original_price) || 4800
+                          )}
+                        </span>
+                      </div>
+                    </CardContent>
+
+                    <CardFooter className="p-4 pt-0 flex gap-2">
+                      <QuickOrderDialog
+                        product={product}
+                        trigger={
+                          <Button className="flex-1 bg-[#0052cc] hover:bg-[#0065ff] text-white font-semibold transition-colors duration-300">
+                            <ShoppingCart className="mr-2 h-4 w-4" />
+                            Нарачај
+                          </Button>
+                        }
+                      />
+
+                      <Button
+                        asChild
+                        variant="outline"
+                        className="border-primary text-primary hover:bg-primary hover:text-primary-foreground"
+                      >
+                        <Link to={`/products/${product.slug}`}>Детали</Link>
+                      </Button>
+                    </CardFooter>
+                  </Card>
+                </ScrollReveal>
               );
             })}
           </div>
         )}
 
         {!isLoading && !isFetching && sortedProducts.length === 0 && (
-          <div className="text-center py-12">
-            <div className="text-4xl mb-4">🔍</div>
-            <h3 className="text-lg font-medium text-foreground mb-2">
+          <ScrollReveal className="text-center py-12 space-y-3">
+            <div className="text-4xl">🔍</div>
+            <h3 className="text-lg font-medium text-foreground">
               Нема најдено производи
             </h3>
             <p className="text-muted-foreground">
@@ -265,7 +265,7 @@ export default function ProductsPage() {
                 ? "Пробајте со различен збор за пребарување или проверете дали има достапни производи."
                 : "Моментално нема објавени производи. Навратете се повторно."}
             </p>
-          </div>
+          </ScrollReveal>
         )}
       </main>
 


### PR DESCRIPTION
## Summary
- add a reusable ScrollReveal helper with supporting styles and hero background motion
- apply entrance animations to marketing sections, product listings, and dialogs for a modern feel
- remove console logging from the frontend API utilities while keeping mock fallbacks intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68fa62a65428833092db7533bad163a5